### PR TITLE
Centrar as imagens  #17

### DIFF
--- a/content/pages/inicio.rst
+++ b/content/pages/inicio.rst
@@ -8,6 +8,7 @@ Python Portugal
 
 
 .. image:: images/python3.png
+    :class: rounded mx-auto d-block
     :align: center
     :alt: homem com cobra na mão e castelo ao fundo com bandeira portuguesa
 


### PR DESCRIPTION
Utilizando o css do bootsrtap para alinhar as imagens basta adicionar nos .rst
 .. image:: patth_image
     **:class: rounded mx-auto d-block**
     :align: center
     :alt: texto

