### PR TITLE
Corrigido titulo do Blog e Artigos

### DIFF
--- a/theme/python-pt/templates/article.html
+++ b/theme/python-pt/templates/article.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% block title %}{{ article.title }} - {{SITENAME}}{% endblock title %}
 {% block content %}
+<h2>{{ category }}</h2>
+<br>
 <section id="content" class="article content">
   <header>
     <h2 class="entry-title">

--- a/theme/python-pt/templates/categories.html
+++ b/theme/python-pt/templates/categories.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %} Articles in {{ category }} - {{ SITENAME }}{% endblock %}
+{% block title %}{{ category }} {{ SITENAME }}{% endblock %}
 {% block archclass %} class="active"{%endblock%}
 {% block content %}
 <ul>

--- a/theme/python-pt/templates/category.html
+++ b/theme/python-pt/templates/category.html
@@ -1,8 +1,9 @@
 {% extends "index.html" %}
-{% block title %} Articles in {{ category }} category - {{ SITENAME }}{% endblock %}
+{% block title %}{{ category }} {{ SITENAME }}{% endblock %}
 {% block navclass %}{%endblock%}
 {% block archclass %} class="active"{%endblock%}
 {% block content_title %}
-<h2>Articles in the {{ category }} category</h2>
+<h2>{{ category }}</h2>
+<br>
 {% endblock %}
 


### PR DESCRIPTION
Corrigido o título da página Blog:

Aparecia "Articles in Blog" e passou só a constar a categoria "Blog".

Nos artigos foi adicionada o título com a categoria "Blog" para ficar enquadrado na página do Blog.